### PR TITLE
fix(zsh): add try command from fish config

### DIFF
--- a/macos/.zshrc
+++ b/macos/.zshrc
@@ -119,6 +119,24 @@ fi
 export WALK_EDITOR=nvim
 function lk { cd "$(walk --icons "$@")"; }
 
+# try — interactive project selector (https://github.com/tobi/try)
+if [ -f "$HOME/.local/try.rb" ]; then
+  function try {
+    local cmd
+    cmd=$(/usr/bin/env ruby "$HOME/.local/try.rb" cd --path "$HOME/src/tries" "$@" 2>/dev/tty)
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+      if echo "$cmd" | grep -q ' && '; then
+        eval "$cmd"
+      else
+        cd "$cmd"
+      fi
+    else
+      echo "$cmd" >&2
+    fi
+  }
+fi
+
 # ── Misc integrations ──
 [[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi


### PR DESCRIPTION
## What

Add the `try` function to zsh config, mirroring the one in fish (`common/.config/fish/config.fish`).

## Why

Running `try` in zsh failed with `zsh: command not found: try` because the function was only defined in the fish config.

## How

Translated the fish `try` function to zsh syntax — checks for `~/.local/try.rb`, runs it via Ruby, then `cd`s or `eval`s the result.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [ ] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `try` shell command that generates and executes commands with support for chaining operations and directory navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->