### PR TITLE
chore: add Tuna launcher alongside Raycast

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ stow -D common
 
 Tools no longer the primary choice (configs preserved in repo for occasional use):
 
+- [Raycast](https://www.raycast.com/) - Launcher (replaced by Tuna)
 - [fnm](https://github.com/Schniz/fnm) - Node.js version manager (replaced by mise)
 - [sourcetreeapp](https://www.sourcetreeapp.com/) - Git GUI
 - [starship](https://starship.rs/) - Prompt (replaced by Pure)
@@ -521,11 +522,11 @@ defaults write com.apple.dock no-bouncing -bool FALSE && killall Dock
 
 ### Leader Key
 
-- Map Right-CMD to Hyper key on Tuna
+- Map Right-CMD to Hyper key on Tuna or Raycast
 - Map Right-shift to Right Cmd-Space
 - Map leader key with Hyper + Space
 
-[![Tuna + Leaderkey](https://i.gyazo.com/27f7df849ca4625e7864efb08f896e72.gif)](https://gyazo.com/27f7df849ca4625e7864efb08f896e72)
+[![Hyper key + Leaderkey](https://i.gyazo.com/27f7df849ca4625e7864efb08f896e72.gif)](https://gyazo.com/27f7df849ca4625e7864efb08f896e72)
 
 ### OBS setting for Blue Yeti Microphone
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ stow -D common
 - [bat](https://github.com/sharkdp/bat) - Cat with syntax highlighting
 - [fd](https://github.com/sharkdp/fd) - Fast find alternative
 - [ripgrep (rg)](https://github.com/BurntSushi/ripgrep) - Line-oriented search tool
-- [raycast](https://www.raycast.com/) - Blazingly fast, totally extendable launcher
+- [Tuna](https://tunaformac.com/) - New, modern launcher for macOS
 - [Marta](https://marta.sh/) - File manager
 - [BetterDisplay](https://github.com/waydabber/BetterDisplay) - Unlock your displays on Mac
 - [OBS](https://obsproject.com/) - Open Broadcaster Software
@@ -521,11 +521,11 @@ defaults write com.apple.dock no-bouncing -bool FALSE && killall Dock
 
 ### Leader Key
 
-- Map Right-CMD to Hyper key on Raycast
+- Map Right-CMD to Hyper key on Tuna
 - Map Right-shift to Right Cmd-Space
 - Map leader key with Hyper + Space
 
-[![Raycast + Leaderkey](https://i.gyazo.com/27f7df849ca4625e7864efb08f896e72.gif)](https://gyazo.com/27f7df849ca4625e7864efb08f896e72)
+[![Tuna + Leaderkey](https://i.gyazo.com/27f7df849ca4625e7864efb08f896e72.gif)](https://gyazo.com/27f7df849ca4625e7864efb08f896e72)
 
 ### OBS setting for Blue Yeti Microphone
 

--- a/common/.config/Cursor/User/keybindings.json
+++ b/common/.config/Cursor/User/keybindings.json
@@ -78,7 +78,7 @@
   // TODO: Wait for this to resolve https://github.com/usernamehw/vscode-error-lens/issues/208
   // Setup which-key
   {
-    "key": "cmd+space", // Disable Spotlight and use Raycast with Alt+space, refer https://manual.raycast.com/hotkey
+    "key": "cmd+space", // Disable Spotlight and use Tuna with Alt+space, refer https://tunaformac.com/docs/replacing-spotlight-with-tuna
     "command": "whichkey.show",
     "when": "editorTextFocus"
   },

--- a/common/.config/Cursor/User/keybindings.json
+++ b/common/.config/Cursor/User/keybindings.json
@@ -78,7 +78,10 @@
   // TODO: Wait for this to resolve https://github.com/usernamehw/vscode-error-lens/issues/208
   // Setup which-key
   {
-    "key": "cmd+space", // Disable Spotlight and use Tuna with Alt+space, refer https://tunaformac.com/docs/replacing-spotlight-with-tuna
+    // Disable Spotlight and use Tuna or Raycast with Alt+space:
+    // https://tunaformac.com/docs/replacing-spotlight-with-tuna
+    // https://manual.raycast.com/hotkey
+    "key": "cmd+space",
     "command": "whichkey.show",
     "when": "editorTextFocus"
   },

--- a/common/.config/cspell-tool.txt
+++ b/common/.config/cspell-tool.txt
@@ -13,7 +13,7 @@ Neovim
 ohmyz
 powerlevel
 alacritty
-raycast
+tuna
 lazygit
 sourcetreeapp
 koekeishiya

--- a/common/.config/cspell-tool.txt
+++ b/common/.config/cspell-tool.txt
@@ -13,6 +13,7 @@ Neovim
 ohmyz
 powerlevel
 alacritty
+raycast
 tuna
 lazygit
 sourcetreeapp

--- a/common/.config/vscode/keybindings.json
+++ b/common/.config/vscode/keybindings.json
@@ -78,7 +78,10 @@
 	// TODO: Wait for this to resolve https://github.com/usernamehw/vscode-error-lens/issues/208
 	// Setup which-key
 	{
-		"key": "cmd+space", // Disable Spotlight and use Tuna with Alt+space, refer https://tunaformac.com/docs/replacing-spotlight-with-tuna
+		// Disable Spotlight and use Tuna or Raycast with Alt+space:
+		// https://tunaformac.com/docs/replacing-spotlight-with-tuna
+		// https://manual.raycast.com/hotkey
+		"key": "cmd+space",
 		"command": "whichkey.show",
 		"when": "editorTextFocus"
 	},

--- a/common/.config/vscode/keybindings.json
+++ b/common/.config/vscode/keybindings.json
@@ -78,7 +78,7 @@
 	// TODO: Wait for this to resolve https://github.com/usernamehw/vscode-error-lens/issues/208
 	// Setup which-key
 	{
-		"key": "cmd+space", // Disable Spotlight and use Raycast with Alt+space, refer https://manual.raycast.com/hotkey
+		"key": "cmd+space", // Disable Spotlight and use Tuna with Alt+space, refer https://tunaformac.com/docs/replacing-spotlight-with-tuna
 		"command": "whichkey.show",
 		"when": "editorTextFocus"
 	},

--- a/macos/.config/leader-key/config.json
+++ b/macos/.config/leader-key/config.json
@@ -115,17 +115,17 @@
           "key" : "p",
           "label" : "",
           "type" : "url",
-          "value" : "raycast://confetti"
+          "value" : "tuna://combo"
         },
         {
           "key" : "c",
           "label" : "",
           "type" : "url",
-          "value" : "raycast://extensions/raycast/system/open-camera"
+          "value" : "tuna://talk"
         }
       ],
       "key" : "r",
-      "label" : "Raycast",
+      "label" : "Tuna",
       "type" : "group"
     },
     {

--- a/macos/.config/leader-key/config.json
+++ b/macos/.config/leader-key/config.json
@@ -113,19 +113,31 @@
       "actions" : [
         {
           "key" : "p",
-          "label" : "",
+          "label" : "Raycast Confetti",
+          "type" : "url",
+          "value" : "raycast://confetti"
+        },
+        {
+          "key" : "c",
+          "label" : "Raycast Camera",
+          "type" : "url",
+          "value" : "raycast://extensions/raycast/system/open-camera"
+        },
+        {
+          "key" : "t",
+          "label" : "Tuna Combo",
           "type" : "url",
           "value" : "tuna://combo"
         },
         {
-          "key" : "c",
-          "label" : "",
+          "key" : "d",
+          "label" : "Tuna Talk",
           "type" : "url",
           "value" : "tuna://talk"
         }
       ],
       "key" : "r",
-      "label" : "Tuna",
+      "label" : "Launchers",
       "type" : "group"
     },
     {

--- a/macos/.skhdrc
+++ b/macos/.skhdrc
@@ -17,8 +17,6 @@ ctrl + alt - b : open -a "Brave Browser"
 ctrl + alt - c : open -a "Cursor"
 ctrl + alt - d : open -a "Navicat Premium Lite"
 ctrl + alt - z : open -a "Zed Preview"
-# Raycast Extensions
-ctrl + alt - p : open "raycast://confetti"
 
 # Communication
 ctrl + alt + shift - z : open -a "zoom.us"

--- a/macos/.skhdrc
+++ b/macos/.skhdrc
@@ -17,6 +17,8 @@ ctrl + alt - b : open -a "Brave Browser"
 ctrl + alt - c : open -a "Cursor"
 ctrl + alt - d : open -a "Navicat Premium Lite"
 ctrl + alt - z : open -a "Zed Preview"
+# Raycast Extensions
+ctrl + alt - p : open "raycast://confetti"
 
 # Communication
 ctrl + alt + shift - z : open -a "zoom.us"
@@ -38,4 +40,3 @@ ctrl + alt + shift - w : open -a "Warp"
 ctrl + alt + shift - e : open -a "Finder"
 ctrl + alt + shift - d : open -a "OrbStack"
 ctrl + alt + shift - v : open -a "Vial"
-

--- a/macos/.yabairc
+++ b/macos/.yabairc
@@ -55,7 +55,7 @@ yabai -m config --space work layout stack
 yabai -m config --space media layout stack
 
 # Unmanaged apps
-app_titles="(Copy|Bin|About This Mac|Info|Finder Preferences|Preferences|QuickTime Player)"
+app_titles="(Copy|Bin|About This Mac|Info|Finder Preferences|Preferences|QuickTime Player|Raycast Settings)"
 yabai -m rule --add title="${app_titles}" manage=off
 
 # Disable tiling for those apps
@@ -64,13 +64,14 @@ yabai -m rule --add app="^CleanMyMac X$" manage=off
 yabai -m rule --add app="^Karabiner-" manage=off
 yabai -m rule --add app="^Sourcetree$" manage=off
 yabai -m rule --add app="^Tuna" manage=off
+yabai -m rule --add app="^Raycast" manage=off
 yabai -m rule --add app="^Iphone" manage=off
 
 # Not working yet
 # yabai -m rule --add app="^Arc" title="^Little Arc" manage=off
 
 # NOTE: Disable SIP for Mac OSX 15, refer https://github.com/koekeishiya/yabai/blob/master/CHANGELOG.md#712---2024-08-10
-# Assign apps to space and Tuna to open
+# Assign apps to space and Tuna or Raycast to open
 # Space 1 - Coding
 yabai -m rule --add app="^(WezTerm|Warp|alacritty|kitty)" space=1
 # Space 2 - Web browsers

--- a/macos/.yabairc
+++ b/macos/.yabairc
@@ -55,7 +55,7 @@ yabai -m config --space work layout stack
 yabai -m config --space media layout stack
 
 # Unmanaged apps
-app_titles="(Copy|Bin|About This Mac|Info|Finder Preferences|Preferences|QuickTime Player|Raycast Settings)"
+app_titles="(Copy|Bin|About This Mac|Info|Finder Preferences|Preferences|QuickTime Player)"
 yabai -m rule --add title="${app_titles}" manage=off
 
 # Disable tiling for those apps
@@ -63,14 +63,14 @@ yabai -m rule --add app="^System Settings$" manage=off
 yabai -m rule --add app="^CleanMyMac X$" manage=off
 yabai -m rule --add app="^Karabiner-" manage=off
 yabai -m rule --add app="^Sourcetree$" manage=off
-yabai -m rule --add app="^Raycast" manage=off
+yabai -m rule --add app="^Tuna" manage=off
 yabai -m rule --add app="^Iphone" manage=off
 
 # Not working yet
 # yabai -m rule --add app="^Arc" title="^Little Arc" manage=off
 
 # NOTE: Disable SIP for Mac OSX 15, refer https://github.com/koekeishiya/yabai/blob/master/CHANGELOG.md#712---2024-08-10
-# Assign apps to space and Raycast to open
+# Assign apps to space and Tuna to open
 # Space 1 - Coding
 yabai -m rule --add app="^(WezTerm|Warp|alacritty|kitty)" space=1
 # Space 2 - Web browsers


### PR DESCRIPTION
## What

Add [Tuna](https://tunaformac.com/) as the primary macOS launcher while preserving Raycast configuration for occasional use.

- README: list Tuna as active and move Raycast to the existing deprecated-tools section
- `macos/.skhdrc`: retain the `raycast://confetti` hotkey
- `macos/.yabairc`: keep Raycast unmanaged-app rules and add Tuna rules
- `macos/.config/leader-key/config.json`: keep Raycast actions and add Tuna Combo/Talk actions under one launcher group
- Cursor and VS Code keybindings: document both launchers' Spotlight alternatives
- `common/.config/cspell-tool.txt`: retain `raycast` and add `tuna`

## Why

Tuna is the new primary launcher, but Raycast remains available as a deprecated tool. Its configuration is intentionally preserved, matching the repository's existing deprecated-tools policy.

## How

- Raycast URL schemes remain available for confetti and camera actions.
- Tuna adds the documented `tuna://combo` and `tuna://talk` URL schemes.
- Yabai excludes both launchers from tiling.
- The existing Leader Key launcher group exposes distinct labeled actions for both tools.

## Checklist

- [x] Documentation updated
- [x] Configuration syntax validated
- [x] No breaking changes
