### PR TITLE
docs: add Try Omarchy to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ stow -D common
 - [git-credential-manager](https://github.com/GitCredentialManager/git-credential-manager/) - Git Credential Manager
 - [EVKey](https://evkeyvn.com/) - Vietnamese Keyboard
 - [Navicat Premium Lite](https://www.navicat.com/en/download/navicat-premium-lite)
+- [Try Omarchy](https://github.com/themartiano/try-omarchy) - Run Omarchy desktop on Apple Silicon (hardware-accelerated VM)
 
 ## Deprecated tools
 


### PR DESCRIPTION
## What

Add [Try Omarchy](https://github.com/themartiano/try-omarchy) to the Tools list in the README.

## Why

Try Omarchy lets you run the upstream [Omarchy](https://github.com/basecamp/omarchy) desktop as a native, hardware-accelerated app on an Apple Silicon Mac. It fits alongside the other macOS tools already tracked in the dotfiles.

## How

- Added a single README entry under the existing Tools section, next to the other macOS utilities.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Try Omarchy to the Tools list, highlighting support for running the Omarchy desktop on Apple Silicon through a hardware-accelerated virtual machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->